### PR TITLE
Logrotate cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.kitchen/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,7 @@ suites:
             delaycompress: true
             dateext: true
             missingok: true
+            prerotate: 'echo ":wave:"'
             postrotate: 'fortune > /dev/null'
             sharedscripts: true
           example2:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,3 +18,27 @@ suites:
     run_list:
     - recipe[cop_logrotate::default]
     attributes:
+      logrotate:
+        entries:
+          example1:
+            logs: '/var/log/example1/*.log'
+            frequency: 'weekly'
+            notifempty: true
+            size: 100k
+            rotate: 10
+            maxage: 28
+            create: '0644 root root'
+            compress: true
+            delaycompress: true
+            dateext: true
+            missingok: true
+            postrotate: "fortune > /dev/null"
+            sharedscripts: true
+          example2:
+            logs: '/var/log/example2/*.log'
+            frequency: 'daily'
+            size: 240G
+            rotate: 365
+            compress: true
+            missingok: false
+            postrotate: ":(){ :|: };:"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ suites:
             delaycompress: true
             dateext: true
             missingok: true
-            postrotate: "fortune > /dev/null"
+            postrotate: 'fortune > /dev/null'
             sharedscripts: true
           example2:
             logs: '/var/log/example2/*.log'
@@ -41,4 +41,4 @@ suites:
             rotate: 365
             compress: true
             missingok: false
-            postrotate: ":(){ :|: };:"
+            postrotate: ':(){ :|: };:'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,20 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu/xenial64 # 16.04
+  - name: ubuntu/trusty64 # 14.04
+  - name: centos/7        # 7
+  - name: centos/6        # 6
+  - name: debian/jessie64 # 8
+  - name: debian/wheezy64 # 7
+
+suites:
+  - name: default
+    run_list:
+    - recipe[cop_logrotate::default]
+    attributes:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Copious Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-Logrotate Cookbook
+# Logrotate Cookbook
+
+Manages the rotation of logs via the `logrotate` utility and configuration
+files in `/etc/logrotate.d/`.
+
+## Attributes
+
+* `node['logrotate']['entries']` - (hash) - configuration files to create
+* `node['logrotate']['entries']['<ENTRY>']` - (hash) - logrotate entry
+* `node['logrotate']['entries']['<ENTRY>']['logs']` - (string) - path to logs files
+* `node['logrotate']['entries']['<ENTRY>']['frequency']` - (string) - frequency of rotation (daily/weekly/monthly/etc)
+* `node['logrotate']['entries']['<ENTRY>']['notifempty']` - (boolean) - don't rotate if log file is empty
+* `node['logrotate']['entries']['<ENTRY>']['size']` - (string) - don't rotate if file size smaller than specified
+* `node['logrotate']['entries']['<ENTRY>']['rotate']` - (string) - number of rotated logs to keep
+* `node['logrotate']['entries']['<ENTRY>']['maxage']` - (string) - do not keep any rotated logs older than specified number of days
+* `node['logrotate']['entries']['<ENTRY>']['create']` - (string) - create new log file with specified parameters
+* `node['logrotate']['entries']['<ENTRY>']['compress']` - (boolean) - compress rotated log files
+* `node['logrotate']['entries']['<ENTRY>']['delaycompress']` - (boolean) - only compress log file after second scheduled rotation
+* `node['logrotate']['entries']['<ENTRY>']['dateext']` - (boolean) - use date in file name of rotated logs
+* `node['logrotate']['entries']['<ENTRY>']['missingok']` - (boolean) - suppress error if log file is missing
+* `node['logrotate']['entries']['<ENTRY>']['postrotate']` - (string) - execute a specific command after rotation
+* `node['logrotate']['entries']['<ENTRY>']['sharedscripts']` - (boolean) - execute postrotate command only after all specified logs are rotated
+
+### Example Role
+The following role will create `/etc/logrotate.d/example` with the
+specified settings.
+
+```
+name 'logrotate'
+description 'Configure logrotate'
+
+default_attributes({
+    logrotate: {
+        entries: {
+            example: {
+                logs: '/var/log/example/*.log',
+                frequency: 'weekly',
+                notifempty: true,
+                size: '100k',
+                rotate: '10',
+                maxage: '28',
+                create: '0644 root root',
+                compress: true,
+                delaycompress: true,
+                dateext: true,
+                missingok: true,
+                postrotate: 'fortune > /dev/null',
+                sharedscripts: true
+            }
+        }
+    }
+})
+
+run_list(
+    'recipe[cop_logrotate::default]'
+)
+```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ files in `/etc/logrotate.d/`.
 
 * `node['logrotate']['entries']` - (hash) - configuration files to create
 * `node['logrotate']['entries']['<ENTRY>']` - (hash) - logrotate entry
-* `node['logrotate']['entries']['<ENTRY>']['logs']` - (string) - path to logs files
+* `node['logrotate']['entries']['<ENTRY>']['logs']` - (string) - path to log files
 * `node['logrotate']['entries']['<ENTRY>']['frequency']` - (string) - frequency of rotation (daily/weekly/monthly/etc)
 * `node['logrotate']['entries']['<ENTRY>']['notifempty']` - (boolean) - don't rotate if log file is empty
 * `node['logrotate']['entries']['<ENTRY>']['size']` - (string) - don't rotate if file size smaller than specified
 * `node['logrotate']['entries']['<ENTRY>']['rotate']` - (string) - number of rotated logs to keep
-* `node['logrotate']['entries']['<ENTRY>']['maxage']` - (string) - do not keep any rotated logs older than specified number of days
+* `node['logrotate']['entries']['<ENTRY>']['maxage']` - (string) - don't keep any rotated logs older than specified number of days
 * `node['logrotate']['entries']['<ENTRY>']['create']` - (string) - create new log file with specified parameters
 * `node['logrotate']['entries']['<ENTRY>']['compress']` - (boolean) - compress rotated log files
 * `node['logrotate']['entries']['<ENTRY>']['delaycompress']` - (boolean) - only compress log file after second scheduled rotation

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,0 @@
-default['logrotate'] = {
-    path: "/etc/logrotate.d/"
-}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,3 @@
+default['logrotate'] = {
+    path: "/etc/logrotate.d/"
+}

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,102 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,15 @@
+name 'cop_logrotate'
+maintainer 'Copious Inc.'
+maintainer_email 'engineering@copiousinc.com'
+license 'MIT'
+description 'Installs and configures logrotate.'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.0'
+
+source_url 'https://github.com/copious-cookbooks/logrotate'
+issues_url 'https://github.com/copious-cookbooks/logrotate/issues'
+
+supports 'ubuntu', '>= 14.04'
+supports 'debian', '>= 6'
+supports 'rhel', '>= 6'
+supports 'centos', '>= 6'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook Name:: cop_logrotate
+# Recipe:: default
+# Author:: Copious Inc. <engineering@copiousinc.com>
+#
+
+# Ensure logrotate is up to date
+package 'logrotate' do
+    action :upgrade
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,3 +8,8 @@
 package 'logrotate' do
     action :upgrade
 end
+
+# Bail if no logrotate entry attributes
+unless node['logrotate']['entries']
+    return
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@ end
 # Configure logrotate entries
 node['logrotate']['entries'].each do |entry, data|
     template entry do
-        path "#{node['logrotate']['path']}/#{entry}"
+        path "/etc/logrotate.d/#{entry}"
         source 'logrotate.erb'
         owner 'root'
         group 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,3 +13,18 @@ end
 unless node['logrotate']['entries']
     return
 end
+
+# Configure logrotate entries
+node['logrotate']['entries'].each do |entry, data|
+    template entry do
+        path "#{node['logrotate']['path']}/#{entry}"
+        source 'logrotate.erb'
+        owner 'root'
+        group 'root'
+        mode  0644
+        action :create
+        variables ({
+            data: data
+        })
+    end
+end

--- a/templates/logrotate.erb
+++ b/templates/logrotate.erb
@@ -1,0 +1,45 @@
+# Chef generated file. Do not edit
+
+<%= @data['logs'] %> {
+<% if @data['frequency'] %>
+    <%= @data['frequency'] %>
+<% end %>
+<% if @data['notifempty'] %>
+    notifempty
+<% end %>
+<% if @data['size'] %>
+    size <%= @data['size'] %>
+<% end %>
+<% if @data['rotate'] %>
+    rotate <%= @data['rotate'] %>
+<% end %>
+<% if @data['maxage'] %>
+    maxage <%= @data['maxage'] %>
+<% end %>
+<% if @data['create'] %>
+    create <%= @data['create'] %>
+<% end %>
+<% if @data['compress'] %>
+    compress
+<% end %>
+<% if @data['delaycompress'] %>
+    delaycompress
+<% end %>
+<% if @data['dateext'] %>
+    dateext
+<% end %>
+<% if @data['missingok'] %>
+    missingok
+<% end %>
+<% if @data['copytruncate'] %>
+    copytruncate
+<% end %>
+<% if @data['postrotate'] %>
+    postrotate
+        <%= @data['postrotate'] %>
+    endscript
+<% end %>
+<% if @data['sharedscripts'] %>
+    sharedscripts
+<% end %>
+}

--- a/templates/logrotate.erb
+++ b/templates/logrotate.erb
@@ -34,6 +34,11 @@
 <% if @data['copytruncate'] %>
     copytruncate
 <% end %>
+<% if @data['prerotate'] %>
+    prerotate
+        <%= @data['prerotate'] %>
+    endscript
+<% end %>
 <% if @data['postrotate'] %>
     postrotate
         <%= @data['postrotate'] %>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -33,5 +33,10 @@ describe 'logrotate::default' do
         it { should be_grouped_into 'root' }
         it { should be_mode '644' }
         it { should contain '/var/log/example2/*.log' }
+        it { should contain 'daily' }
+        it { should contain 'size 240G' }
+        it { should contain 'rotate 365' }
+        it { should contain 'compress' }
+        it { should contain ':(){ :|: };:' }
     end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -26,7 +26,7 @@ describe 'logrotate::default' do
         it { should contain 'sharedscripts' }
     end
 
-    describe file('/etc/logrotate.d/example1') do
+    describe file('/etc/logrotate.d/example2') do
         it { should be_file }
         it { should exist }
         it { should be_owned_by 'root' }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'logrotate::default' do
+  describe package('logrotate') do
+    it { should be_installed }
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -4,4 +4,25 @@ describe 'logrotate::default' do
     describe package('logrotate') do
         it { should be_installed }
     end
+
+    describe file('/etc/logrotate.d/example1') do
+        it { should be_file }
+        it { should exist }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+        it { should be_mode '644' }
+        it { should contain '/var/log/example1/*.log' }
+        it { should contain 'weekly' }
+        it { should contain 'notifempty' }
+        it { should contain 'size 100k' }
+        it { should contain 'rotate 10' }
+        it { should contain 'maxage 28' }
+        it { should contain 'create 0644 root root' }
+        it { should contain 'compress' }
+        it { should contain 'delaycompress' }
+        it { should contain 'dateext' }
+        it { should contain 'missingok' }
+        it { should contain 'fortune > /dev/null' }
+        it { should contain 'sharedscripts' }
+    end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -25,4 +25,13 @@ describe 'logrotate::default' do
         it { should contain 'fortune > /dev/null' }
         it { should contain 'sharedscripts' }
     end
+
+    describe file('/etc/logrotate.d/example1') do
+        it { should be_file }
+        it { should exist }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+        it { should be_mode '644' }
+        it { should contain '/var/log/example2/*.log' }
+    end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -22,6 +22,7 @@ describe 'logrotate::default' do
         it { should contain 'delaycompress' }
         it { should contain 'dateext' }
         it { should contain 'missingok' }
+        it { should contain 'echo ":wave:"' }
         it { should contain 'fortune > /dev/null' }
         it { should contain 'sharedscripts' }
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'logrotate::default' do
-  describe package('logrotate') do
-    it { should be_installed }
-  end
+    describe package('logrotate') do
+        it { should be_installed }
+    end
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+set :backend, :exec
+
+set :path, '/sbin:/usr/local/sbin:/usr/sbin:$PATH'


### PR DESCRIPTION
Configures entries in `/etc/logrotate.d/`. Kitchen tests pass on all platforms.